### PR TITLE
Updates for Sopel 7.1/8.0, plus bugfix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-sopel>=6.0,<7
+sopel>=7.1
+requests  # sopel itself requires this, but it's best to be explicit

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-sopel>=6.0,<7
+sopel>=7.1
 pytest==4.4.0
 pytest-runner==4.4
 coverage==4.5.3

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open('NEWS') as history_file:
 with open('requirements.txt') as requirements_file:
     requirements = [req for req in requirements_file.readlines()]
 
-with open('dev-requirements.txt') as dev_requirements_file:
+with open('requirements_dev.txt') as dev_requirements_file:
     dev_requirements = [req for req in dev_requirements_file.readlines()]
 
 

--- a/sopel_modules/birthdays/birthdays.py
+++ b/sopel_modules/birthdays/birthdays.py
@@ -7,7 +7,7 @@ import itertools
 import random
 import textwrap
 
-import sopel.module
+import sopel.plugin
 import sopel.formatting
 import requests
 
@@ -45,8 +45,7 @@ def split_msg(days):
     return lines
 
 
-@sopel.module.commands('bdays')
-@sopel.module.commands('ddays')
+@sopel.plugin.commands('bdays', 'ddays')
 def bdays(bot, trigger):
     r = requests.get('https://history.muffinlabs.com/date')
     rj = r.json()

--- a/sopel_modules/birthdays/birthdays.py
+++ b/sopel_modules/birthdays/birthdays.py
@@ -50,9 +50,9 @@ def bdays(bot, trigger):
     r = requests.get('https://history.muffinlabs.com/date')
     rj = r.json()
 
-    if trigger.args[1] == '.bdays':
+    if trigger.group(1) == 'bdays':
         names = get_births(rj)
-    elif trigger.args[1] == '.ddays':
+    elif trigger.group(1) == 'ddays':
         names = get_deaths(rj)
 
     colours = random.sample(['01', '02', '03', '04', '06', '08', '11'], 7)


### PR DESCRIPTION
### Updates

`dev-requirements.txt` was unused; deleted it and updated references to use `requirements_dev.txt` instead.

Added `requests` as an explicit runtime requirement, in case Sopel drops it someday.

In Sopel 7.1, `sopel.module` was deprecated and replaced with `sopel.plugin`.

### Bugfix

The plugin assumed all bots would use the default prefix of `.` which caused an error on bots that used something else:

```
17:39:41 <~dgw> 'bdays
17:39:43 <SopelGitpod> Unexpected UnboundLocalError (local variable 'names' referenced before assignment) from dgw.
                       Message was: 'bdays
```

### Future

I had to select an older version of Python with `pyenv` because this plugin couldn't be installed (in editable mode) on Python 3.12. `setup.py` packaging is also somewhat deprecated, and should be replaced with `pyproject.toml` or at the least `setup.cfg` package metadata, but I didn't want to take this PR too far.